### PR TITLE
Final customization version of vault-k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BIN_NAME=$(IMAGE_NAME)_$(GOOS)_$(GOARCH)_$(VERSION)
 all: build
 
 build:
-	GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -a -o $(BUILD_DIR)/$(BIN_NAME) .
+	GO111MODULE=on CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -a -o $(BUILD_DIR)/$(BIN_NAME) .
 
 image: build
 	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) -f $(DOCKER_DIR)/Dev.dockerfile .

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -12,12 +12,12 @@ func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 
 	// WebSummit: Added consul agent env var
 	envs = append(envs, corev1.EnvVar{
-		Name:  "CONSUL_HTTP_ADDR",
-		ValueFrom: corev1.EnvVarSource{
-			FieldRef: corev1.ObjectFieldSelector{
-				FieldPath: "status.hostIP"
-			}
-		}
+		Name:  "HOST_IP",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.hostIP",
+			},
+		},
 	})
 
 	if a.Vault.ClientTimeout != "" {

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -34,7 +34,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && consul login -method kubernetes -bearer-token-file '/run/secrets/kubernetes.io/serviceaccount/token' -token-sink-file '/home/vault/consul.token' && export CONSUL_HTTP_TOKEN=$(cat /home/vault/consul.token) && touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
+		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -34,7 +34,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
+		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && consul login -method kubernetes -bearer-token-file '/run/secrets/kubernetes.io/serviceaccount/token' -token-sink-file '/home/vault/consul.token' && export CONSUL_HTTP_TOKEN=$(cat /home/vault/consul.token) && touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -46,7 +46,7 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && consul login -method kubernetes -bearer-token-file '/run/secrets/kubernetes.io/serviceaccount/token' -token-sink-file '/home/vault/consul.token' && export CONSUL_HTTP_TOKEN=$(cat /home/vault/consul.token) && touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
+		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {


### PR DESCRIPTION
Since we are now injecting the token directly to our baked custom-vault-agent image the only thing we need from this custom-vault-k8s injector is to add HOST_IP env variable and include the command to read that env variable to generate the CONSUL_HTTP_ADDR.