### PR TITLE
Consul support upgraded to v0.10.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 REGISTRY_NAME?=docker.io/hashicorp
+WS_REGISTRY_NAME?=docker.io/websummit
 IMAGE_NAME=vault-k8s
+WS_IMAGE_NAME=custom-$(IMAGE_NAME)
 VERSION?=0.10.2
+WS_VERSION?=0.2-$(IMAGE_NAME)-$(VERSION)
 IMAGE_TAG?=$(REGISTRY_NAME)/$(IMAGE_NAME):$(VERSION)
+WS_IMAGE_TAG?=$(WS_REGISTRY_NAME)/$(WS_IMAGE_NAME):$(WS_VERSION)
 PUBLISH_LOCATION?=https://releases.hashicorp.com
 DOCKER_DIR=./build/docker
 BUILD_DIR=.build
@@ -19,6 +23,12 @@ build:
 
 image: build
 	docker build --build-arg VERSION=$(VERSION) --no-cache -t $(IMAGE_TAG) -f $(DOCKER_DIR)/Dev.dockerfile .
+
+ws-image:
+	docker buildx build -t $(WS_IMAGE_TAG) \
+	--platform linux/amd64,linux/arm64 \
+	-f $(DOCKER_DIR)/WSRelease.dockerfile \
+	--push .
 
 #This target is used as part of the release pipeline in CircleCI, but can also be used to build the production image locally.
 #The released/signed linux binary will be pulled from releases.hashicorp.com instead of a local build of the binary.

--- a/agent-inject/agent/container_env.go
+++ b/agent-inject/agent/container_env.go
@@ -10,6 +10,15 @@ import (
 func (a *Agent) ContainerEnvVars(init bool) ([]corev1.EnvVar, error) {
 	var envs []corev1.EnvVar
 
+	envs = append(envs, corev1.EnvVar{
+		Name: "HOST_IP",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.hostIP",
+			},
+		},
+	})
+
 	if a.Vault.ClientTimeout != "" {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "VAULT_CLIENT_TIMEOUT",

--- a/agent-inject/agent/container_env_test.go
+++ b/agent-inject/agent/container_env_test.go
@@ -14,12 +14,12 @@ func TestContainerEnvs(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{}, []string{"VAULT_CONFIG"}},
-		{Agent{ConfigMapName: "foobar"}, []string{}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
-		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
-		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
+		{Agent{}, []string{"HOST_IP", "VAULT_CONFIG"}},
+		{Agent{ConfigMapName: "foobar"}, []string{"HOST_IP"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0"}}, []string{"HOST_IP", "VAULT_CONFIG", "VAULT_MAX_RETRIES"}},
+		{Agent{Vault: Vault{ClientTimeout: "5s"}}, []string{"HOST_IP", "VAULT_CONFIG", "VAULT_CLIENT_TIMEOUT"}},
+		{Agent{Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s"}}, []string{"HOST_IP", "VAULT_CONFIG", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT"}},
+		{Agent{ConfigMapName: "foobar", Vault: Vault{ClientMaxRetries: "0", ClientTimeout: "5s", LogLevel: "info", ProxyAddress: "http://proxy:3128"}}, []string{"HOST_IP", "VAULT_MAX_RETRIES", "VAULT_CLIENT_TIMEOUT", "VAULT_LOG_LEVEL", "HTTPS_PROXY"}},
 	}
 
 	for _, tt := range tests {
@@ -44,9 +44,9 @@ func TestContainerEnvsForIRSA(t *testing.T) {
 		agent        Agent
 		expectedEnvs []string
 	}{
-		{Agent{Pod: testPodWithoutIRSA()}, []string{"VAULT_CONFIG"}},
-		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws",}}, 
-			[]string{"VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
+		{Agent{Pod: testPodWithoutIRSA()}, []string{"HOST_IP", "VAULT_CONFIG"}},
+		{Agent{Pod: testPodWithIRSA(), Vault: Vault{AuthType: "aws"}},
+			[]string{"HOST_IP", "VAULT_CONFIG", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"},
 		},
 	}
 	for _, tt := range envTests {

--- a/agent-inject/agent/container_init_sidecar.go
+++ b/agent-inject/agent/container_init_sidecar.go
@@ -53,7 +53,7 @@ func (a *Agent) ContainerInitSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
+		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && touch %s && vault agent -config=%s/config-init.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -65,7 +65,7 @@ func (a *Agent) ContainerSidecar() (corev1.Container, error) {
 			MountPath: configVolumePath,
 			ReadOnly:  true,
 		})
-		arg = fmt.Sprintf("touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
+		arg = fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
 	}
 
 	if a.Vault.TLSSecret != "" {

--- a/agent-inject/agent/container_sidecar.go
+++ b/agent-inject/agent/container_sidecar.go
@@ -11,10 +11,10 @@ import (
 
 const (
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu
-	DefaultResourceLimitCPU   = "500m"
-	DefaultResourceLimitMem   = "128Mi"
-	DefaultResourceRequestCPU = "250m"
-	DefaultResourceRequestMem = "64Mi"
+	DefaultResourceLimitCPU   = "200m"
+	DefaultResourceLimitMem   = "64Mi"
+	DefaultResourceRequestCPU = "100m"
+	DefaultResourceRequestMem = "32Mi"
 	DefaultContainerArg       = "echo ${VAULT_CONFIG?} | base64 -d > /home/vault/config.json && vault agent -config=/home/vault/config.json"
 	DefaultRevokeGrace        = 5
 	DefaultAgentLogLevel      = "info"

--- a/agent-inject/agent/container_sidecar_test.go
+++ b/agent-inject/agent/container_sidecar_test.go
@@ -204,36 +204,44 @@ func TestContainerSidecar(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 4
+	expectedEnvs := 5
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	if container.Env[0].Name != "VAULT_LOG_LEVEL" {
+	if container.Env[0].Name != "HOST_IP" {
+		t.Errorf("env name wrong, should have been %s, got %s", "HOST_IP", container.Env[0].Name)
+	}
+
+	if container.Env[0].Value != "" {
+		t.Error("env value is not empty, it should be")
+	}
+
+	if container.Env[1].Name != "VAULT_LOG_LEVEL" {
 		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_LEVEL", container.Env[0].Name)
-	}
-
-	if container.Env[0].Value == "" {
-		t.Error("env value empty, it shouldn't be")
-	}
-
-	if container.Env[1].Name != "VAULT_LOG_FORMAT" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_FORMAT", container.Env[1].Name)
-	}
-
-	if container.Env[2].Name != "HTTPS_PROXY" {
-		t.Errorf("env name wrong, should have been %s, got %s", "HTTPS_PROXY", container.Env[2].Name)
 	}
 
 	if container.Env[1].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
-	if container.Env[3].Name != "VAULT_CONFIG" {
-		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[3].Name)
+	if container.Env[2].Name != "VAULT_LOG_FORMAT" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_LOG_FORMAT", container.Env[1].Name)
+	}
+
+	if container.Env[3].Name != "HTTPS_PROXY" {
+		t.Errorf("env name wrong, should have been %s, got %s", "HTTPS_PROXY", container.Env[2].Name)
 	}
 
 	if container.Env[2].Value == "" {
+		t.Error("env value empty, it shouldn't be")
+	}
+
+	if container.Env[4].Name != "VAULT_CONFIG" {
+		t.Errorf("env name wrong, should have been %s, got %s", "VAULT_CONFIG", container.Env[3].Name)
+	}
+
+	if container.Env[3].Value == "" {
 		t.Error("env value empty, it shouldn't be")
 	}
 
@@ -378,12 +386,12 @@ func TestContainerSidecarConfigMap(t *testing.T) {
 		t.Errorf("creating container sidecar failed, it shouldn't have: %s", err)
 	}
 
-	expectedEnvs := 2
+	expectedEnvs := 3
 	if len(container.Env) != expectedEnvs {
 		t.Errorf("wrong number of env vars, got %d, should have been %d", len(container.Env), expectedEnvs)
 	}
 
-	arg := fmt.Sprintf("touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
+	arg := fmt.Sprintf("export CONSUL_HTTP_ADDR=$HOST_IP:8500 && touch %s && vault agent -config=%s/config.hcl", TokenFile, configVolumePath)
 	if container.Args[0] != arg {
 		t.Errorf("arg value wrong, should have been %s, got %s", arg, container.Args[0])
 	}

--- a/build/docker/WSRelease.dockerfile
+++ b/build/docker/WSRelease.dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:latest as builder
+
+RUN apk add go build-base
+
+ARG GOOS=linux
+
+COPY . .
+
+RUN apkArch="$(apk --print-arch)" && \
+    case "${apkArch}" in \
+        aarch64) ARCH='arm64' ;; \
+        armhf) ARCH='arm' ;; \
+        x86) ARCH='386' ;; \
+        x86_64) ARCH='amd64' ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${LOCATION}/${NAME}/${VERSION}/)" && exit 1 ;; \
+    esac && \
+    GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -a -o vault-k8s .
+
+FROM alpine:latest
+
+RUN addgroup vault && \
+    adduser -S -G vault vault
+
+COPY --from=builder vault-k8s /vault-k8s
+
+USER vault
+
+ENTRYPOINT ["/vault-k8s"]


### PR DESCRIPTION
- Port the changes needed for consul support on top of the latest upstream version 0.10.2
- Fix tests to keep it clean
- Port the changes to default requests and limits
- Add information to README about the motivation, changes and usage.